### PR TITLE
[rake] Corrects rake spec to report true build status

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
+require 'rspec/core/rake_task'
+
 task :default => [:spec]
 
-task :spec do
-  system 'rspec'
-end
+RSpec::Core::RakeTask.new(:spec)

--- a/lib/transmission.rb
+++ b/lib/transmission.rb
@@ -6,5 +6,5 @@ require File.join(File.dirname(__FILE__), 'transmission', 'arguments')
 require File.join(File.dirname(__FILE__), 'transmission', 'utils')
 
 module Transmission
-  VERSION = '0.3.1'
+  VERSION = '0.3.1'.freeze
 end


### PR DESCRIPTION
Build step was exiting with code 0, even when tests fail. This causes Travis to report a [successful build](https://travis-ci.org/transmission-rails/transmission-rpc-ruby/builds/188384287), even though tests have failed.
> The command "bundle exec rake" exited with 0.

```sh
transmission-rpc-ruby (master) > rake
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
F............................

Failures:

  1) this test fails intentionally
     Failure/Error: expect(true).to eq(false)
     
       expected: false
            got: true
     
       (compared using ==)
     # ./spec/spec_helper.rb:19:in `block (2 levels) in <top (required)>'

Finished in 0.21924 seconds (files took 0.40102 seconds to load)
95 examples, 1 failure

Failed examples:

rspec ./spec/spec_helper.rb:18 # this test fails intentionally

[Coveralls] Outside the CI environment, not sending data.
transmission-rpc-ruby (master) > echo $?
0 #=> should be 1
```

Changed the definition of `rake spec` to use library rake task instead of a `system` call. This causes exit code to be set correctly.